### PR TITLE
feat: 'back to chat' button redirects to where settings were opened from

### DIFF
--- a/frontend/components/ChatSidebar.tsx
+++ b/frontend/components/ChatSidebar.tsx
@@ -96,9 +96,17 @@ function PureHeader() {
 const Header = memo(PureHeader);
 
 const PureFooter = () => {
+  const { id: chatId } = useParams();
+
   return (
     <SidebarFooter>
-      <Link to="/settings" className={buttonVariants({ variant: 'outline' })}>
+      <Link
+        to={{
+          pathname: "/settings",
+          search: chatId ? `?from=${chatId}` : "",
+        }}
+        className={buttonVariants({ variant: "outline" })}
+      >
         Settings
       </Link>
     </SidebarFooter>

--- a/frontend/routes/Settings.tsx
+++ b/frontend/routes/Settings.tsx
@@ -2,12 +2,15 @@ import APIKeyForm from '@/frontend/components/APIKeyForm';
 import { Link } from 'react-router';
 import { buttonVariants } from '../components/ui/button';
 import { ArrowLeftIcon } from 'lucide-react';
+import { useSearchParams } from 'next/navigation';
 
 export default function Settings() {
+  const chatId = useSearchParams().get("from")
+
   return (
     <section className="flex w-full h-full">
       <Link
-        to="/chat"
+        to={`/chat${chatId ? `/${chatId}` : ""}`}
         className={buttonVariants({
           variant: 'default',
           className: 'w-fit fixed top-10 left-40 z-10',


### PR DESCRIPTION
Back to chat button in settings now goes back to the chat from which settings were opened instead of going back to new chat.

How it works:
- Settings button in the sidebar appends a 'from' search param in the settings URL if a chat is opened.
- 'Back to search' button redirects to that chat if it finds a 'from' URL search param.